### PR TITLE
Added option to specify direction to `canScrollVertically` method, bumped version to 1.6

### DIFF
--- a/flowlayoutmanager/build.gradle
+++ b/flowlayoutmanager/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 
 project.ext {
-    libVersion = '1.5'
-    libVersionCode = 15
+    libVersion = '1.6'
+    libVersionCode = 16
     libGroupId = 'com.xiaofeng.android'
     libArtifactId = 'flowlayoutmanager'
     gitUrl = 'git@github.com:xiaofeng-han/AndroidLibs.git'

--- a/flowlayoutmanager/build.gradle
+++ b/flowlayoutmanager/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 
 project.ext {
-    libVersion = '1.6'
-    libVersionCode = 16
+    libVersion = '1.6.1'
+    libVersionCode = 17
     libGroupId = 'com.xiaofeng.android'
     libArtifactId = 'flowlayoutmanager'
     gitUrl = 'git@github.com:xiaofeng-han/AndroidLibs.git'

--- a/flowlayoutmanager/build.gradle
+++ b/flowlayoutmanager/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 
 project.ext {
-    libVersion = '1.6.1'
-    libVersionCode = 17
+    libVersion = '1.6'
+    libVersionCode = 16
     libGroupId = 'com.xiaofeng.android'
     libArtifactId = 'flowlayoutmanager'
     gitUrl = 'git@github.com:xiaofeng-han/AndroidLibs.git'

--- a/flowlayoutmanager/src/main/java/com/xiaofeng/flowlayoutmanager/FlowLayoutManager.java
+++ b/flowlayoutmanager/src/main/java/com/xiaofeng/flowlayoutmanager/FlowLayoutManager.java
@@ -22,7 +22,11 @@ import java.util.List;
  */
 public class FlowLayoutManager extends RecyclerView.LayoutManager {
 
-	private static final String LOG_TAG = "FlowLayoutManager";
+    private static final String LOG_TAG = "FlowLayoutManager";
+
+    private static final int SCROLL_UP = -1;
+    private static final int SCROLL_DOWN = 1;
+
     private RecyclerView recyclerView;
     private int firstChildAdapterPosition = 0;
     private RecyclerView.Recycler recyclerRef;
@@ -195,23 +199,28 @@ public class FlowLayoutManager extends RecyclerView.LayoutManager {
             return false;
         }
 
-        View firstChild = getChildAt(0);
-        View lastChild = getChildAt(getChildCount() - 1);
-        View topChild = getChildAt(getMaxHeightLayoutPositionInLine(0));
-        View bottomChild = getChildAt(getMaxHeightLayoutPositionInLine(getChildCount() - 1));
-        boolean topReached = false, bottomReached = false;
-        if (getChildAdapterPosition(firstChild) == 0) {
-            if (getDecoratedTop(topChild) >= topVisibleEdge()) {
-                topReached = true;
-            }
-        }
+        return canScrollVertically(SCROLL_UP) || canScrollVertically(SCROLL_DOWN);
+    }
 
-        if (getChildAdapterPosition(lastChild) == recyclerView.getAdapter().getItemCount() - 1) {
-            if (getDecoratedBottom(bottomChild) <= bottomVisibleEdge()) {
-                bottomReached = true;
-            }
+    /**
+     * Check if this view can be scrolled vertically in a certain direction.
+     *
+     * @param direction Negative to check scrolling up, positive to check scrolling down.
+     * @return true if this view can be scrolled in the specified direction, false otherwise.
+     */
+    public boolean canScrollVertically(final int direction) {
+        if (direction < 0) {
+            final View firstChild = getChildAt(0);
+            final View topChild = getChildAt(getMaxHeightLayoutPositionInLine(0));
+
+            return !(getChildAdapterPosition(firstChild) == 0 && getDecoratedTop(topChild) >= topVisibleEdge());
+        } else {
+            View lastChild = getChildAt(getChildCount() - 1);
+            View bottomChild = getChildAt(getMaxHeightLayoutPositionInLine(getChildCount() - 1));
+
+            return !(getChildAdapterPosition(lastChild) == recyclerView.getAdapter().getItemCount() - 1
+                    && getDecoratedBottom(bottomChild) <= bottomVisibleEdge());
         }
-        return !(topReached && bottomReached);
     }
 
     @Override

--- a/flowlayoutmanager/src/main/java/com/xiaofeng/flowlayoutmanager/FlowLayoutManager.java
+++ b/flowlayoutmanager/src/main/java/com/xiaofeng/flowlayoutmanager/FlowLayoutManager.java
@@ -219,7 +219,7 @@ public class FlowLayoutManager extends RecyclerView.LayoutManager {
             View bottomChild = getChildAt(getMaxHeightLayoutPositionInLine(getChildCount() - 1));
 
             return !(getChildAdapterPosition(lastChild) == recyclerView.getAdapter().getItemCount() - 1
-                    && getDecoratedBottom(bottomChild) <= bottomVisibleEdge());
+                    && (bottomChild != null && getDecoratedBottom(bottomChild) <= bottomVisibleEdge()));
         }
     }
 


### PR DESCRIPTION
I needed to know if the LayoutManager could scroll in a specific direction, so I added a new helper method, reusing the code in the original `canScrollVertically()` method